### PR TITLE
Subset URI links currently broken/404, link it out properly

### DIFF
--- a/src/doc-templates/subset.md.jinja2
+++ b/src/doc-templates/subset.md.jinja2
@@ -11,7 +11,7 @@ _{{ element_description_line }}_
 {% endfor %}
 {% endif %}
 
-URI: {{ gen.uri_link(element) }}
+URI: {{ gen.link(element) }}
 
 {% include "common_metadata.md.jinja2" %}
 


### PR DESCRIPTION
Upon clicking the URIs on subset pages, currently, we are routed to a broken/404 page. This PR seeks to fix the subset documentation pages such that the URI hyperlinks resolve properly.